### PR TITLE
Removes JDK11 incompatible ENDORSED dirs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,6 +37,8 @@ tomcat_catalina_base: "{{ tomcat_catalina_base_install_dir }}/tomcat"
 tomcat_catalina_home_install_dir: "/usr/local"
 tomcat_catalina_home: "{{ tomcat_catalina_home_install_dir }}/tomcat"
 tomcat_working_dir: "/home/{{ tomcat_user }}"
+# This is only compatible with JDK 8 and older
+tomcat_java_endorsed_dirs: []
 
 
 ########################################

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,7 +12,7 @@
 
 tomcat_major_version: 9
 tomcat_version: 9.0.33
-tomcat_mirror: "http://mirrors.ibiblio.org/apache"
+tomcat_mirror: "https://archive.apache.org/dist"
 tomcat_download_url: "{{ tomcat_mirror }}/tomcat/tomcat-{{ tomcat_major_version }}/v{{ tomcat_version }}/bin/apache-tomcat-{{ tomcat_version }}.tar.gz"
 tomcat_checksum_url: "https://downloads.apache.org/tomcat/tomcat-{{ tomcat_major_version }}/v{{ tomcat_version }}/bin/apache-tomcat-{{ tomcat_version }}.tar.gz.sha512"
 

--- a/templates/catalina_base.bin.setenv.sh.j2
+++ b/templates/catalina_base.bin.setenv.sh.j2
@@ -10,8 +10,10 @@ export JAVA_HOME
 export {{ sysenvvar.name }}
 {% endfor %}
 
-JAVA_ENDORSED_DIRS={{ tomcat_catalina_base }}/endorsed
+{% if tomcat_java_endorsed_dirs|length > 0 %}
+JAVA_ENDORSED_DIRS={{ tomcat_java_endorsed_dirs|join(':') }}
 export JAVA_ENDORSED_DIRS
+{% endif %}
 
 if [ $1 == "start" ] ; then
   export CATALINA_OPTS="-Xmx{{ tomcat_max_heap }} -XX:-DisableExplicitGC -Djava.awt.headless=true -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=8090 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dsun.security.ssl.allowUnsafeRenegotiation=true {{ tomcat_extra_java_opts }}


### PR DESCRIPTION
JAVA_ENDORSED_DIRS is no longer compatible with JDK 11. This changes makes that setting optional and defaults it to empty, since the role defaults to installing JDK 11.