### PR TITLE
create catalina logs directory with write permissions for tomcat_user

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -93,7 +93,9 @@
   file: path="{{ tomcat_catalina_home }}" state=directory owner="root" group="{{ tomcat_group }}" mode=0750
   tags: ['tomcat']
 
-
+- name: create logs directory in CATALINA_HOME
+  file: path="{{ tomcat_catalina_home }}/logs" state=directory owner="{{ tomcat_user }}" group="{{ tomcat_group }}" mode=0750
+  tags: ['tomcat']
 
 - name: ensure /etc/init.d/tomcat exists
   template:


### PR DESCRIPTION
open to other ways of handling this, but the problem as it stands is that {{ tomcat_catalina_home }}/logs doesn't exist and /usr/local/tomcat/bin/catalina.sh expects it.  Presumably tomcat_user will need to be able to write to it.