### PR TITLE
stop removing the logs directory for tomcat

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -64,7 +64,6 @@
     path: "{{ tomcat_catalina_home }}/{{ item }}"
     state: absent
   with_items:
-    - logs
     - work
     - temp
     - bin/*.bat
@@ -93,7 +92,7 @@
   file: path="{{ tomcat_catalina_home }}" state=directory owner="root" group="{{ tomcat_group }}" mode=0750
   tags: ['tomcat']
 
-- name: create logs directory in CATALINA_HOME
+- name: ensure logs directory exists in CATALINA_HOME
   file: path="{{ tomcat_catalina_home }}/logs" state=directory owner="{{ tomcat_user }}" group="{{ tomcat_group }}" mode=0750
   tags: ['tomcat']
 


### PR DESCRIPTION
Okay so I missed this the first time.  We actually remove the logs directory ourselves, and then I was recreating it.  I'm leaving my creation as is because it ensures permissions are right, but as it stands the role is non-idempotent for a few steps 